### PR TITLE
Missing values and data types

### DIFF
--- a/cfjson/xrdataset.py
+++ b/cfjson/xrdataset.py
@@ -14,7 +14,7 @@ logging.basicConfig()
 encoder.FLOAT_REPR = lambda o: format(o, '.4f').rstrip('0').rstrip('.')
 
 AXIS_VAR=['time','lat','latitude','lon','longitude','site']
-SPECIAL_ATTRS=['missing_value','cell_methods']
+SPECIAL_ATTRS=['type', 'missing_value','cell_methods']
 
 @xr.register_dataset_accessor('cfjson')
 class CFJSONinterface(object):
@@ -64,15 +64,17 @@ class CFJSONinterface(object):
                 else:
                     res['variables'][varout]['shape'] = []
                 for att in self._obj.variables[var].attrs:
-                    if att not in SPECIAL_ATTRS:
-                        newatt=self._obj.variables[var].attrs[att]
+                    newatt=self._obj.variables[var].attrs[att]
+                    print(att, newatt)
+                    if att in SPECIAL_ATTRS:
+                       # res['variables'][varout][att]=newatt
+                        pass
+                    else:
                         try:
                             newatt=float(newatt)
                         except:
                             newatt=str(newatt)
-                        res['variables'][varout][att]=newatt
-                    else:
-                        res['variables'][varout][att]=self._obj.variables[var].attrs[att]
+                        res['variables'][varout][att]['attributes']=newatt
             except:
                 print('Failed to export variable %s description or attributes'%(var))
                 raise

--- a/cfjson/xrdataset.py
+++ b/cfjson/xrdataset.py
@@ -71,6 +71,8 @@ class CFJSONinterface(object):
                         except:
                             newatt=str(newatt)
                         res['variables'][varout]['attributes'][att]=newatt
+                    else:
+                        res['variables'][varout]['attributes'][att]=self._obj.variables[var].attrs[att]
             except:
                 print('Failed to export variable %s description or attributes'%(var))
                 raise

--- a/cfjson/xrdataset.py
+++ b/cfjson/xrdataset.py
@@ -70,9 +70,9 @@ class CFJSONinterface(object):
                             newatt=float(newatt)
                         except:
                             newatt=str(newatt)
-                        res['variables'][varout]['attributes'][att]=newatt
+                        res['variables'][varout][att]=newatt
                     else:
-                        res['variables'][varout]['attributes'][att]=self._obj.variables[var].attrs[att]
+                        res['variables'][varout][att]=self._obj.variables[var].attrs[att]
             except:
                 print('Failed to export variable %s description or attributes'%(var))
                 raise

--- a/cfjson/xrdataset.py
+++ b/cfjson/xrdataset.py
@@ -65,16 +65,14 @@ class CFJSONinterface(object):
                     res['variables'][varout]['shape'] = []
                 for att in self._obj.variables[var].attrs:
                     newatt=self._obj.variables[var].attrs[att]
-                    print(att, newatt)
                     if att in SPECIAL_ATTRS:
-                       # res['variables'][varout][att]=newatt
-                        pass
+                        res['variables'][varout][att]=newatt
                     else:
                         try:
                             newatt=float(newatt)
                         except:
                             newatt=str(newatt)
-                        res['variables'][varout][att]['attributes']=newatt
+                        res['variables'][varout]['attributes'][att]=newatt
             except:
                 print('Failed to export variable %s description or attributes'%(var))
                 raise

--- a/cfjson/xrdataset.py
+++ b/cfjson/xrdataset.py
@@ -14,7 +14,7 @@ logging.basicConfig()
 encoder.FLOAT_REPR = lambda o: format(o, '.4f').rstrip('0').rstrip('.')
 
 AXIS_VAR=['time','lat','latitude','lon','longitude','site']
-SPECIAL_ATTRS=['type', 'missing_value','cell_methods']
+SPECIAL_ATTRS=['missing_value','cell_methods']
 
 @xr.register_dataset_accessor('cfjson')
 class CFJSONinterface(object):
@@ -63,6 +63,9 @@ class CFJSONinterface(object):
                     res['variables'][varout]['shape'] = vardims
                 else:
                     res['variables'][varout]['shape'] = []
+                # There seems to be no built-in function in Python to convert numpy datatypes to Python datatypes, apart from this convoluted way
+                res['variables'][varout]['type'] = type(np.zeros(1, self._obj.dtypes[var].name).item()).__name__
+
                 for att in self._obj.variables[var].attrs:
                     newatt=self._obj.variables[var].attrs[att]
                     if att in SPECIAL_ATTRS:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 
 NAME = "cfjson"
-VERSION = "0.3.7"
+VERSION = "0.4.0"
 
 # To install the library, run the following
 #


### PR DESCRIPTION
So far the code just discarded variable attributes in the "SPECIAL_VARS" list. If I understand correctly, these are supposed to be listed "outside" the "attributes" dictionary in the JSON.
Changes:
* "SPECIAL VARS" now get added to output on the same level as "shape".
* "type" now gets added as well, it extracts it from the xarray datatypes.
This now produces output which looks the same as the cf-json output from the 1-minute-obs API ([this one](https://anypoint.mulesoft.com/exchange/portals/metservice/a5d2add2-fb59-4b2a-a1e4-0b25ffbe51db/1-minute-observations-api/minor/4.3/pages/home/), not the MetOcean one).
 